### PR TITLE
Fix coverage collection in tox.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source = src
+source = zope.errorview
 
 [report]
 exclude_lines =


### PR DESCRIPTION
Closes #8.

Incidentally, the coverage is 100% under all supported Python versions, but if I add

    coverage report -m --fail-under=100

this breaks `tox -p auto` rather badly (all the coverage processes running in parallel try to use the same .coverage data file at once, with predictably bad results.)

The right thing to do is to apply the magic meta template so we get GitHub Actions and everything.  I'm not feeling up to it at the moment.