### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 3.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 2.1 (2025-09-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  CHANGES
 =========
 
-2.2 (unreleased)
+3.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ tests_require = [
 ] + browser_requires
 
 setup(name='zope.errorview',
-      version='2.2.dev0',
+      version='3.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.dev',
       description='Basic HTTP and Browser exception views.',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -37,7 +36,7 @@ browser_requires = [
 
 tests_require = [
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ] + browser_requires
 
 setup(name='zope.errorview',
@@ -72,9 +71,6 @@ setup(name='zope.errorview',
       ],
       url='https://github.com/zopefoundation/zope.errorview',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope'],
       python_requires='>=3.9',
       extras_require={
           'test': tests_require,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
